### PR TITLE
fix IndexError when press mount but no iso available

### DIFF
--- a/gadget_cdrom.py
+++ b/gadget_cdrom.py
@@ -137,7 +137,12 @@ class State:
     def insert_iso(self):
         self.remove_iso()
         script = os.path.join(APP_DIR, "insert_iso.sh")
-        iso_name = self.iso_ls()[self.get_iso_select()]
+        iso_list = self.iso_ls()
+        if not iso_list:
+            LOGGER.error("No ISO available.")
+            return
+        
+        iso_name = iso_list[self.get_iso_select()]
         LOGGER.info("Inserting %s: %s", self._mode, iso_name)
         self._iso_name = iso_name
         subprocess.check_call((script, iso_name, self._mode))


### PR DESCRIPTION
When there are no \*.iso/\*.img files uploaded, a press of the `mount` button leads to this error:

```
DEBUG:__main__:isolist: []
DEBUG:__main__:Pressed mount
Traceback (most recent call last):
  File "/opt/gadget_cdrom/gadget_cdrom.py", line 382, in <module>
    Main().main()
  File "/opt/gadget_cdrom/gadget_cdrom.py", line 355, in main
    f()
  File "/opt/gadget_cdrom/gadget_cdrom.py", line 370, in _button_mount
    self._state.insert_iso()
  File "/opt/gadget_cdrom/gadget_cdrom.py", line 140, in insert_iso
    iso_name = self.iso_ls()[self.get_iso_select()]
               ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
IndexError: list index out of range
```
